### PR TITLE
add cleanup script and bump setup sleep

### DIFF
--- a/lambda-cleanup.sh
+++ b/lambda-cleanup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+if [[ ! -x /usr/local/bin/jq ]]; then
+  echo "this script requires jq"
+else
+  ebspolicyarn="$(aws iam list-policies|jq -r '.Policies[]|select((.PolicyName == "makesnap3-policy"))|.Arn')"
+  functionarn="$(aws events list-targets-by-rule --rule makesnap-daily|jq -r '.Targets[].Arn')"
+
+  aws iam detach-role-policy --role-name ebs-snapshot --policy-arn "$ebspolicyarn"
+  aws iam detach-role-policy --role-name ebs-snapshot --policy-arn "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+  aws iam delete-role --role-name ebs-snapshot
+
+  aws iam delete-policy --policy-arn "$ebspolicyarn"
+
+  aws lambda delete-function --function-name makesnap3
+
+  for period in hourly daily weekly monthly; do
+    aws events remove-targets --rule "makesnap-${period}" --ids 1
+    aws events delete-rule --name "makesnap-${period}"
+  done
+fi

--- a/lambda-setup.sh
+++ b/lambda-setup.sh
@@ -46,7 +46,7 @@ echo
 echo "... and upload it to Lambda to create function"
 echo "(IAM policy application lags sometimes, we'll sleep for 15 seconds)"
 echo 
-sleep 10
+sleep 15
 
 function_arn=` \
 aws lambda create-function \


### PR DESCRIPTION
Howdy, and thanks for the script!

I set up with the script, and included a log file in my `config.json`. This broke the internet, and re-running the setup script wasn't clean, so I made a cleanup script (as a likely precursor to turning the setup script into a CFN template).

Also noticed, while I was in there, that the text declares a sleep 15 but actually sleeps 10.
