### PR TITLE
Support for AWS named profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Quick start (cron)
 - Install boto3
 
 ```sh
-
+    
     $ pip install boto3
 ```
-Next, set up credentials (in e.g. ``~/.aws/credentials``):
+Next, set up credentials (in e.g. ``~/.aws/credentials``). You can use the default profile or use another one. ([More info at AWS CLI documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles)) :
 
 ```ini
 
@@ -74,6 +74,7 @@ Notes
         'keep_month': 3,
         'keep_hour': 4,
         'log_file': 'makesnapshots.log',
+        'aws_profile_name': 'default'
 ```
 - Snapshots of busy volumes may take long time. If you have a lot of (or) busy volumes - don't use Lambda. Maximum timeout for Lambda is 300s and there's currently no way to disable or confgiure retry on error (if you know - let me know, please).
 

--- a/makesnap3.py
+++ b/makesnap3.py
@@ -20,7 +20,8 @@ from datetime import datetime
 
 config_defaults = {
     'tag_name': 'MakeSnapshot', 'tag_value': 'true',
-    'keep_hour': 4, 'keep_day': 3, 'keep_week': 4, 'keep_month': 3
+    'keep_hour': 4, 'keep_day': 3, 'keep_week': 4, 'keep_month': 3,
+    'aws_profile_name':'default'
 }
 
 now_format = {'hour': '%R', 'day': '%a', 'week': '%U', 'month': '%b'}
@@ -101,6 +102,8 @@ def log_setup(logfile):
 def main(period):
     config = read_config('config.json', config_defaults)
     log_setup(config.get('log_file', None))
+
+    boto3.setup_default_session(profile_name=config.get('aws_profile_name', 'default'))
 
     stats = {
         'total_vols': 0, 'total_errors': 0,


### PR DESCRIPTION
Hi! Thanks for the script and the port to boto3. 

Since I already had a user with a specific profile I needed to use a second one. To do that, AWS CLI supports named profiles, also boto3. 

I thought it would be handy if you could specify which profile do you want to use in the config file, and if no profile is selected use "default" by default, so I made it.

I think it would be useful for people in the same situation. 
