### PR TITLE
Feature/tag instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Features
 
 Quick start (cron)
 =========
-- (Optional) Create an IAM user to execute the script with the [following policy](makesnapshot-policy.json). If you're impatient or like to live dangerously, you can always resort to running it with AWS root or IAM admin privileges.
+- (Optional) Create an IAM user to execute the script with the [following policy](makesnapshot-policy.json). If you're impatient or like to live dangerously, you can always resort to running it with AWS root or IAM admin privileges.  If you will only snapshot from volume tags, not instances, you can omit the "ec2:DescribeInstances" permission.
 
 - Install boto3
 
 ```sh
-    
+
     $ pip install boto3
 ```
 Next, set up credentials (in e.g. ``~/.aws/credentials``). You can use the default profile or use another one. ([More info at AWS CLI documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles)) :
@@ -89,4 +89,3 @@ TODO
 Credits
 =========
 This script started as a boto3 rewrite of the excellent makesnapshot tool (https://github.com/evannuil/aws-snapshot-tool)
-

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Notes
         'keep_month': 3,
         'keep_hour': 4,
         'log_file': 'makesnapshots.log',
-        'aws_profile_name': 'default'
+        'aws_profile_name': 'default',
+        'tag_type': 'volume',
+        'running_only': false,
         'ec2_region_name': 'us-west-2'
 ```
 - Snapshots of busy volumes may take long time. If you have a lot of (or) busy volumes - don't use Lambda. Maximum timeout for Lambda is 300s and there's currently no way to disable or confgure retry on error (if you know - let me know, please).

--- a/makesnap3.py
+++ b/makesnap3.py
@@ -22,7 +22,8 @@ from datetime import datetime
 config_defaults = {
     'tag_name': 'MakeSnapshot', 'tag_value': 'true',
     'keep_hour': 4, 'keep_day': 3, 'keep_week': 4, 'keep_month': 3,
-    'aws_profile_name':'default'
+    'aws_profile_name':'default',
+    'tag_type': 'volume'
 }
 
 now_format = {'hour': '%R', 'day': '%a', 'week': '%U', 'month': '%b'}
@@ -101,7 +102,6 @@ def log_setup(logfile):
 
 
 def main(period, config_file='config.json'):
-    print(config_file)
     config = read_config(config_file, config_defaults)
     log_setup(config.get('log_file', None))
 
@@ -207,10 +207,7 @@ if __name__ == '__main__':
     period=str(args.period)
 
     if len(sys.argv) > 1 and now_format.get(args.period, None):
-
         sys.exit(main(period, config_file=config_file))
     else:
         print('Usage: {} {{hour|day|week|month}}'.format(sys.argv[0]))
         sys.exit(1)
-
-

--- a/makesnap3.py
+++ b/makesnap3.py
@@ -27,6 +27,7 @@ config_defaults = {
     'keep_week': 4,
     'keep_month': 3,
     'aws_profile_name': 'default',
+    'running_only': False,
     'tag_type': 'volume'
 }
 

--- a/makesnap3.py
+++ b/makesnap3.py
@@ -94,7 +94,6 @@ def get_vols(ec2_resource, tag_name, tag_value, tag_type='volume', running_only=
     print("looking for tags of type %s " % tag_type)
     if tag_type == 'volume':
         vols = ec2_resource.volumes.filter(Filters=[{'Name': 'tag:' + tag_name, 'Values': [tag_value]}]).all()
-        sys.exit(1)
         return vols
     elif tag_type == 'instance':
         instance_filters = [{'Name': 'tag:' + tag_name, 'Values': [tag_value]}]

--- a/makesnap3.py
+++ b/makesnap3.py
@@ -213,13 +213,14 @@ if __name__ == '__main__':
 
     # Command Line Args
     arg_parser = argparse.ArgumentParser(description='')
-    arg_parser.add_argument('-c', '--config', help='configuration file to load', type=str)
-    arg_parser.add_argument('period')
+    arg_parser.add_argument('-c', '--config', help='configuration file to load', type=str, default='config.json')
+    arg_parser.add_argument('period', choices=['hour', 'day', 'week', 'month'])
     args = arg_parser.parse_args()
+
     config_file = str(args.config)
     period = str(args.period)
 
-    if len(sys.argv) > 1 and now_format.get(args.period, None):
+    if now_format.get(args.period, None):
         sys.exit(main(period, config_file=config_file))
     else:
         print('Usage: {} {{hour|day|week|month}}'.format(sys.argv[0]))

--- a/makesnap3.py
+++ b/makesnap3.py
@@ -10,6 +10,7 @@ Usage::
     $ makesnap3.py {hour|day|week|month}
 """
 
+import argparse
 import boto3
 import sys
 import re
@@ -99,8 +100,9 @@ def log_setup(logfile):
         log.addHandler(fh)
 
 
-def main(period):
-    config = read_config('config.json', config_defaults)
+def main(period, config_file='config.json'):
+    print(config_file)
+    config = read_config(config_file, config_defaults)
     log_setup(config.get('log_file', None))
 
     # Set profile name only if it's explicitly defined if config file
@@ -194,9 +196,21 @@ def lambda_handler(event, context):
         return 1
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1 and now_format.get(sys.argv[1], None):
-        period = sys.argv[1]
-        sys.exit(main(period))
+    # period = sys.argv[1]
+
+    # Command Line Args
+    arg_parser = argparse.ArgumentParser(description='')
+    arg_parser.add_argument('-c', '--config', help='configuration file to load', type=str)
+    arg_parser.add_argument('period')
+    args = arg_parser.parse_args()
+    config_file=str(args.config)
+    period=str(args.period)
+
+    if len(sys.argv) > 1 and now_format.get(args.period, None):
+
+        sys.exit(main(period, config_file=config_file))
     else:
         print('Usage: {} {{hour|day|week|month}}'.format(sys.argv[0]))
         sys.exit(1)
+
+

--- a/makesnapshot-policy.json
+++ b/makesnapshot-policy.json
@@ -3,15 +3,6 @@
     "Statement": [
         {
             "Action": [
-                "sns:Publish"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-                "arn:aws:sns:*"
-            ]
-        },
-        {
-            "Action": [
                 "ec2:DescribeAvailabilityZones"
             ],
             "Effect": "Allow",
@@ -25,6 +16,7 @@
                 "ec2:CreateTags",
                 "ec2:DeleteSnapshot",
                 "ec2:DescribeSnapshots",
+                "ec2:DescribeInstances",
                 "ec2:DescribeTags",
                 "ec2:DescribeVolumeAttribute",
                 "ec2:DescribeVolumeStatus",


### PR DESCRIPTION
I didn't spend a lot of time on this, and I'm not _sure_ you'll want it, but I've added three features here:
1. the ability to tag the instances, rather then the volumes
2. when tagging the instances, the ability to limit to only running instances
3. the ability to pass a config file as an arg.  This is an easy way to configure different schedules for different tags, different aws accounts, different regions, etc.

If you want it and want changes, let me know.  Otherwise, I prefer you to close the PR rather than leaving it in limbo.  Thanks!
