### PR TITLE
Fix adding "None" tags to snapshot

### DIFF
--- a/makesnap3.py
+++ b/makesnap3.py
@@ -239,7 +239,8 @@ def main(period, config_file='config.json'):
                     log.info(
                         ">> Creating snapshot for volume %s: '%s'", vol.id, description)
                     current_snap = vol.create_snapshot(Description=description)
-                    current_snap.create_tags(Tags=vol.tags)
+                    if vol.tags is not None:
+                        current_snap.create_tags(Tags=vol.tags)
                     stats['snap_creates'] += 1
                 except Exception as err:
                     stats['snap_errors'] += 1


### PR DESCRIPTION
When creating the snapshot, the tags of the volume are copied to it, but if the volume has no tags boto3 complain with "tags can not be None" and, although the snapshot is created correctly, it is counted as a error.

This is a small fix to check that the tags of a volume are not `None` before copying them.